### PR TITLE
Use configured `ivFieldName` during encryption

### DIFF
--- a/lib/mcapi/crypto/field-level-crypto.js
+++ b/lib/mcapi/crypto/field-level-crypto.js
@@ -41,6 +41,8 @@ function FieldLevelCrypto(config) {
 
   this.oaepHashingAlgorithmFieldName = config.oaepHashingAlgorithmFieldName;
 
+  this.ivFieldName = config.ivFieldName || 'iv';
+
   /**
    * Perform data encryption
    *
@@ -71,7 +73,7 @@ function FieldLevelCrypto(config) {
         encrypted,
         this.encoding
       ),
-      iv: utils.bytesToString(enc.iv, this.encoding),
+      [this.ivFieldName]: utils.bytesToString(enc.iv, this.encoding),
       [this.encryptedKeyFieldName]: utils.bytesToString(
         enc.encryptedKey,
         this.encoding

--- a/test/field-level-crypto.test.js
+++ b/test/field-level-crypto.test.js
@@ -222,7 +222,24 @@ describe("Field Level Crypto", () => {
       assert.ok(resp.iv);
       assert.ok(resp.oaepHashingAlgorithm);
     });
+
+    it("with custom ivFieldName object", () => {
+      const config = JSON.parse(JSON.stringify(testConfig));
+      config.ivFieldName = 'IvCustomName';
+      const crypto = new Crypto(config);
+      const data = JSON.stringify({ text: "message with custom ivFieldName" });
+      const resp = crypto.encryptData({
+        data: data,
+      });
+      assert.ok(resp);
+      assert.ok(resp.encryptedKey);
+      assert.ok(resp.encryptedData);
+      assert.ok(resp.IvCustomName);
+      assert.ok(!resp.iv);
+      assert.ok(resp.oaepHashingAlgorithm);
+    });
   });
+
 
   describe("#decryptData()", () => {
     let crypto;


### PR DESCRIPTION
#### Description
The `ivFieldName` configuration property was ignored during encryption. This PR updates the `encryptData()` function to use the `ivFieldName` from the configuration object. 

#### This PR fixes the issue: https://github.com/Mastercard/client-encryption-nodejs/issues/37. 