### PR TITLE
Added support to allow certificate content to be passed directly - JWE

### DIFF
--- a/lib/mcapi/crypto/field-level-crypto.js
+++ b/lib/mcapi/crypto/field-level-crypto.js
@@ -13,20 +13,9 @@ const c = require("../utils/constants");
 function FieldLevelCrypto(config) {
   isValidConfig.call(this, config);
 
-  //Load public/private keys from text
-  if(config.useCertificateContent){
-    this.encryptionCertificate = utils.readPublicCertificateContent(config);
-    this.privateKey = utils.getPrivateKeyFromContent(config);
-   }
-  // Load public certificate (for encryption)
-  else{
-    this.encryptionCertificate = utils.readPublicCertificate(
-      config.encryptionCertificate
-    );
+  this.encryptionCertificate = utils.readPublicCertificate(config);
+  this.privateKey = utils.getPrivateKey(config);
 
-    // Load private key (for decryption)
-    this.privateKey = utils.getPrivateKey(config);
-  }
   this.encoding = config.dataEncoding;
 
   this.publicKeyFingerprint =

--- a/lib/mcapi/crypto/jwe-crypto.js
+++ b/lib/mcapi/crypto/jwe-crypto.js
@@ -14,10 +14,7 @@ const nodeCrypto = require("crypto");
 function JweCrypto(config) {
   isValidConfig.call(this, config);
 
-  this.encryptionCertificate = readPublicCertificate(
-    config.encryptionCertificate
-  );
-
+  this.encryptionCertificate = readPublicCertificate(config);
   this.privateKey = getPrivateKey(config);
 
   this.publicKeyFingerprint =
@@ -175,8 +172,8 @@ function deSerialize(jweToken) {
 /**
  * @private
  */
-function readPublicCertificate(publicCertificatePath) {
-  const publicCertificate = utils.readPublicCertificate(publicCertificatePath);
+function readPublicCertificate(config) {
+  const publicCertificate = utils.readPublicCertificate(config);
   if (publicCertificate) {
     return forge.pki.certificateToPem(publicCertificate);
   } else {

--- a/lib/mcapi/utils/utils.js
+++ b/lib/mcapi/utils/utils.js
@@ -161,7 +161,24 @@ function deleteRoot(obj, paths, properties) {
   }
 }
 
-module.exports.getPrivateKey = function (config) {
+function getPrivateKeyFromContent (config) {
+  if (config.privateKey) {
+    return forge.pki.privateKeyFromPem(config.privateKey);
+  }
+  return null;
+}
+
+module.exports.getPrivateKey = function(config) {
+  let privateKey;
+  if(config.useCertificateContent){
+    privateKey = getPrivateKeyFromContent(config);
+  } else {
+    privateKey = getPrivateKey(config);
+  }
+  return privateKey;
+}
+
+function getPrivateKey (config) {
   if (config.privateKey) {
     return loadPrivateKey(config.privateKey);
   } else if (config.keyStore) {
@@ -180,7 +197,7 @@ module.exports.getPrivateKey = function (config) {
     }
   }
   return null;
-};
+}
 
 function getPrivateKey12(p12Path, alias, password) {
   const p12Content = fs.readFileSync(p12Path, "binary");
@@ -249,14 +266,6 @@ function loadPrivateKey(privateKeyPath) {
 
   return forge.pki.privateKeyFromAsn1(forge.asn1.fromDer(privateKeyContent));
 }
-
-module.exports.readPublicCertificate = function (publicCertificatePath) {
-  const certificateContent = fs.readFileSync(publicCertificatePath);
-  if (!certificateContent || certificateContent.length <= 1) {
-    throw new Error("Public certificate content is not valid");
-  }
-  return forge.pki.certificateFromPem(certificateContent);
-};
 
 module.exports.computePublicFingerprint = function (
   config,
@@ -426,16 +435,27 @@ module.exports.addEncryptedDataToBody = function(encryptedData, path, encryptedV
   return body;
 };
 
-module.exports.readPublicCertificateContent = function (config) {
+function readPublicCertificateContent (config) {
   if (!config.encryptionCertificate || config.encryptionCertificate.length <= 1) {
     throw new Error("Public certificate content is not valid");
   }
-    return forge.pki.certificateFromPem(config.encryptionCertificate);
+  return forge.pki.certificateFromPem(config.encryptionCertificate);
 }
 
-module.exports.getPrivateKeyFromContent = function(config) {
-  if (config.privateKey) {
-    return forge.pki.privateKeyFromPem(config.privateKey);
+function readPublicCertificate (publicCertificatePath) {
+  const certificateContent = fs.readFileSync(publicCertificatePath);
+  if (!certificateContent || certificateContent.length <= 1) {
+    throw new Error("Public certificate content is not valid");
   }
-  return null;
+  return forge.pki.certificateFromPem(certificateContent);
 }
+
+module.exports.readPublicCertificate = function (config) {
+  let publicCertificate;
+  if(config.useCertificateContent){
+    publicCertificate = readPublicCertificateContent(config);
+  } else {
+    publicCertificate = readPublicCertificate(config.encryptionCertificate);
+  }
+  return publicCertificate;
+};

--- a/lib/mcapi/utils/utils.js
+++ b/lib/mcapi/utils/utils.js
@@ -176,7 +176,7 @@ module.exports.getPrivateKey = function(config) {
     privateKey = getPrivateKey(config);
   }
   return privateKey;
-}
+};
 
 function getPrivateKey (config) {
   if (config.privateKey) {

--- a/test/field-level-crypto.test.js
+++ b/test/field-level-crypto.test.js
@@ -26,7 +26,7 @@ const encryptionCertificateText = '-----BEGIN CERTIFICATE-----'+
 'U4z2iBNq/RWBgYxypi/8NMYZ1RcCrAVSt3QnW6Gp+vW/HrE7KIlAp1gFdme3Xcx1'+
 'vDRpA+MeeEyrnc4UNIqT/4bHGkKlIMKdcjZgrFfEJVFav3eJ4CZ7ZSV6Bx+9yRCL'+
 'DPGlRJLISxgwsOTuUmLOxjotRxO8TdR5e1V+skEtfEctMuSVYA=='+
-'-----END CERTIFICATE-----'
+'-----END CERTIFICATE-----';
 
 describe("Field Level Crypto", () => {
   describe("#new Crypto", () => {

--- a/test/jwe-crypto.test.js
+++ b/test/jwe-crypto.test.js
@@ -5,6 +5,26 @@ const utils = require("../lib/mcapi/utils/utils");
 
 const testConfig = require("./mock/jwe-config");
 
+const encryptionCertificateText = '-----BEGIN CERTIFICATE-----'+
+  'MIIDITCCAgmgAwIBAgIJANLIazc8xI4iMA0GCSqGSIb3DQEBBQUAMCcxJTAjBgNV'+
+  'BAMMHHd3dy5qZWFuLWFsZXhpcy1hdWZhdXZyZS5jb20wHhcNMTkwMjIxMDg1MTM1'+
+  'WhcNMjkwMjE4MDg1MTM1WjAnMSUwIwYDVQQDDBx3d3cuamVhbi1hbGV4aXMtYXVm'+
+  'YXV2cmUuY29tMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA9Mp6gEFp'+
+  '9E+/1SS5XrUyYKMbE7eU0dyJCfmJPz8YOkOYV7ohqwXQvjlaP/YazZ6bbmYfa2WC'+
+  'raOpW0o2BYijHgQ7z2a2Az87rKdAtCpZSKFW82Ijnsw++lx7EABI3tFF282ZV7LT'+
+  '13n9m4th5Kldukk9euy+TuJqCvPu4xzE/NE+l4LFMr8rfD47EPQkrun5w/TXwkmJ'+
+  'rdnG9ejl3BLQO06Ns6Bs516geiYZ7RYxtI8Xnu0ZC0fpqDqjCPZBTORkiFeLocEP'+
+  'RbTgo1H+0xQFNdsMH1/0F1BI+hvdxlbc3+kHZFZFoeBMkR3jC8jDXOXNCMNWb13T'+
+  'in6HqPReO0KW8wIDAQABo1AwTjAdBgNVHQ4EFgQUDtqNZacrC6wR53kCpw/BfG2C'+
+  't3AwHwYDVR0jBBgwFoAUDtqNZacrC6wR53kCpw/BfG2Ct3AwDAYDVR0TBAUwAwEB'+
+  '/zANBgkqhkiG9w0BAQUFAAOCAQEAJ09tz2BDzSgNOArYtF4lgRtjViKpV7gHVqtc'+
+  '3xQT9ujbaxEgaZFPbf7/zYfWZfJggX9T54NTGqo5AXM0l/fz9AZ0bOm03rnF2I/F'+
+  '/ewhSlHYzvKiPM+YaswaRo1M1UPPgKpLlRDMO0u5LYiU5ICgCNm13TWgjBlzLpP6'+
+  'U4z2iBNq/RWBgYxypi/8NMYZ1RcCrAVSt3QnW6Gp+vW/HrE7KIlAp1gFdme3Xcx1'+
+  'vDRpA+MeeEyrnc4UNIqT/4bHGkKlIMKdcjZgrFfEJVFav3eJ4CZ7ZSV6Bx+9yRCL'+
+  'DPGlRJLISxgwsOTuUmLOxjotRxO8TdR5e1V+skEtfEctMuSVYA=='+
+  '-----END CERTIFICATE-----';
+
 describe("JWE Crypto", () => {
   before(function () {
     if (!utils.nodeVersionSupportsJWE()) {
@@ -158,6 +178,24 @@ describe("JWE Crypto", () => {
         /Config not valid: found multiple configurations encrypt\/decrypt with root mapping/
       );
     });
+
+    it("With useCertificateContent enabled, with valid encryption certificate content and without private key", () => {
+      const config = JSON.parse(JSON.stringify(testConfig));
+      config.useCertificateContent = true;
+      config.encryptionCertificate = encryptionCertificateText;
+      delete config["privateKey"];
+      assert.doesNotThrow(() => new Crypto(config));
+    });
+
+    it("With useCertificateContent enabled, without encryptionCertificate", () => {
+      const config = JSON.parse(JSON.stringify(testConfig));
+      config.useCertificateContent = true;
+      config.encryptionCertificate = null;
+      assert.throws(
+        () => new Crypto(config),
+        /Config not valid: please check that all the properties are defined/
+      );
+    });
   });
 
   describe("#encryptData()", () => {
@@ -221,7 +259,7 @@ describe("JWE Crypto", () => {
     it("not valid key", () => {
       const readPublicCertificate = Crypto.__get__("readPublicCertificate");
       assert.throws(() => {
-        readPublicCertificate("./test/res/empty.key");
+        readPublicCertificate({encryptionCertificate: "./test/res/empty.key"});
       }, /Public certificate content is not valid/);
     });
   });

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -400,15 +400,7 @@ describe("Utils", () => {
   describe("#readPublicCertificate", () => {
     it("not valid key", () => {
       assert.throws(() => {
-        utils.readPublicCertificate("./test/res/empty.key");
-      }, /Public certificate content is not valid/);
-    });
-  });
-
-  describe("#ToEncodedString", () => {
-    it("not valid key", () => {
-      assert.throws(() => {
-        utils.readPublicCertificate("./test/res/empty.key");
+        utils.readPublicCertificate({encryptionCertificate:"./test/res/empty.key"});
       }, /Public certificate content is not valid/);
     });
   });


### PR DESCRIPTION
<!-- Please check the completed items below -->
### PR checklist

- [-] An issue/feature request has been created for this PR
- [x] Pull Request title clearly describes the work in the pull request and the Pull Request description provides details about how to validate the work. Missing information here may result in a delayed response.
- [x] File the PR against the `master` branch
- [x] The code in this PR is covered by unit tests

#### Link to issue/feature request: N/A

#### Description
Extending functionality of [this](https://github.com/Mastercard/client-encryption-nodejs/pull/40) to include JWE encryption. This will allow us to pull certs directly from strings, required for Postman collection scripts.