### PR TITLE
Fix body and header argument number for ApiClient generated with openapi-generator 6.1.0

### DIFF
--- a/lib/mcapi/mcapi-service.js
+++ b/lib/mcapi/mcapi-service.js
@@ -35,13 +35,13 @@ function Service(service, config) {
     function (original, outObj) {
       return function () {
         const endpoint = arguments[0];
-        const header = arguments[5];
-        const body = arguments[7];
+        const header = arguments[arguments.length - 9];
+        const body = arguments[arguments.length - 7];
         const cb = arguments[arguments.length - 1];
         if (body) {
           const encrypted = outObj.encryption.encrypt(endpoint, header, body);
-          arguments[5] = encrypted.header;
-          arguments[7] = encrypted.body;
+          arguments[arguments.length - 9] = encrypted.header;
+          arguments[arguments.length - 7] = encrypted.body;
         }
         arguments[arguments.length - 1] = function (error, data, response) {
           if (response && response.body) {

--- a/test/mcapi-service.test.js
+++ b/test/mcapi-service.test.js
@@ -19,7 +19,7 @@ describe("MC API Service", () => {
       }, /service should be a valid OpenAPI client./);
     });
 
-    it("callApi intercepted", function (done) {
+    it("callApi intercepted for ApiClient with collectionQueryParams", function (done) {
       const postBody = {
         elem1: {
           encryptedData: {
@@ -51,6 +51,57 @@ describe("MC API Service", () => {
         { test: "header" },
         null,
         postBody,
+        null,
+        null,
+        null,
+        null,
+        null,
+        function cb(error, data) {
+          assert.ok(data.elem1.encryptedData);
+          assert.ok(data.elem1.encryptedKey);
+          assert.ok(data.elem1.publicKeyFingerprint);
+          assert.ok(data.elem1.oaepHashingAlgorithm);
+          done();
+        }
+      );
+    });
+
+    it("callApi intercepted for ApiClient without collectionQueryParams", function (done) {
+      const postBody = {
+        elem1: {
+          encryptedData: {
+            accountNumber: "5123456789012345",
+          },
+        },
+      };
+      const service = {
+        ApiClient: {
+          instance: {
+            callApi: function () {
+              arguments[arguments.length - 1](null, arguments[6], {
+                body: arguments[6],
+                request: { url: "/resource" },
+              });
+            },
+          },
+        },
+      };
+      const mcService = new MCService(service, testConfig);
+      // simulate callApi call from client
+      service.ApiClient.instance.callApi.call(
+        mcService,
+        "/resource",
+        "POST",
+        null,
+        null,
+        { test: "header" },
+        null,
+        postBody,
+        null,
+        null,
+        null,
+        null,
+        null,
         function cb(error, data) {
           assert.ok(data.elem1.encryptedData);
           assert.ok(data.elem1.encryptedKey);


### PR DESCRIPTION
<!-- Please check the completed items below -->
### PR checklist

- [x] An issue/feature request has been created for this PR
- [x] Pull Request title clearly describes the work in the pull request and the Pull Request description provides details about how to validate the work. Missing information here may result in a delayed response.
- [x] File the PR against the `main` branch
- [x] The code in this PR is covered by unit tests

#### Link to issue/feature request: N/A

#### Description
Openapi-generator 5.2.0 creates 14 arguments for callApi function with collectionQueryParams being 4th parameter and headerParams = 5, bodyParam = 7. With the latest Openapi-generator (6.1.0) there is no collectionQueryParams argument hence headerParams = 4, bodyParam = 6. The fix addresses argument number change and is backward compatible with old openapi-generator version.
