### PR TITLE
Add ability to encrypt and decrypt first level field with JWE

### DIFF
--- a/lib/mcapi/crypto/jwe-crypto.js
+++ b/lib/mcapi/crypto/jwe-crypto.js
@@ -156,7 +156,7 @@ function JweCrypto(config) {
     let data = decipher.update(encryptedText, c.BASE64, c.UTF8);
     data += decipher.final(c.UTF8);
 
-    return JSON.parse(data);
+    return utils.stringToJson(data);
   };
 }
 

--- a/lib/mcapi/encryption/jwe-encryption.js
+++ b/lib/mcapi/encryption/jwe-encryption.js
@@ -83,9 +83,9 @@ function encryptBody(path, body) {
 function decryptBody(path, body) {
   const elem = utils.elemFromPath(path.element, body);
   if (elem && elem.node) {
-    const decryptedObj = this.crypto.decryptData(
-      elem.node[this.config.encryptedValueFieldName]
-    );
+    const encryptedValue = (path.element === this.config.encryptedValueFieldName) ?
+      elem.node : elem.node[this.config.encryptedValueFieldName];
+    const decryptedObj = this.crypto.decryptData(encryptedValue);
     return utils.mutateObjectProperty(
       path.obj,
       decryptedObj,

--- a/lib/mcapi/utils/utils.js
+++ b/lib/mcapi/utils/utils.js
@@ -76,13 +76,35 @@ module.exports.jsonToString = function (data) {
   }
   if (data === "") throw new Error("Json not valid");
   try {
-    if ((typeof data === "string" || data instanceof String) && isJson(data)) {
-      return JSON.stringify(JSON.parse(data));
+    if (typeof data === "string" || data instanceof String) {
+      return isJson(data) ? JSON.stringify(JSON.parse(data)) : data.valueOf();
     } else {
       return JSON.stringify(data);
     }
   } catch (e) {
     throw new Error("Json not valid");
+  }
+};
+
+/**
+ * Convert Json string to Json object if it is a valid Json
+ * Return back input string if it is not a Json
+ *
+ * @param {string} Json string or string
+ * @returns {Object|string}
+ */
+module.exports.stringToJson = function (data) {
+  if (typeof data === "undefined" || data === null) {
+    throw new Error("Input not valid");
+  }
+  if (data === "") throw new Error("String is empty");
+  if (!(typeof data === "string" || data instanceof String)) {
+    throw new Error("Input should be a string");
+  }
+  try {
+    return JSON.parse(data);
+  } catch (e) {
+    return data.valueOf();
   }
 };
 
@@ -431,6 +453,9 @@ module.exports.addEncryptedDataToBody = function(encryptedData, path, encryptedV
     path.element !== path.obj + "." + encryptedValueFieldName
   ) {
     this.deleteNode(path.element, body);
+  }
+  if (encryptedValueFieldName === path.obj) {
+    encryptedData = encryptedData[encryptedValueFieldName];
   }
   body = this.mutateObjectProperty(path.obj, encryptedData, body);
   return body;

--- a/test/jwe-crypto.test.js
+++ b/test/jwe-crypto.test.js
@@ -189,6 +189,24 @@ describe("JWE Crypto", () => {
       assert.ok(resp[3].length === 24);
       assert.ok(resp[4].length === 22);
     });
+
+    it("encrypt primitive string", () => {
+      const data = "message";
+      let resp = crypto.encryptData({
+        data: data,
+      });
+      resp = resp[testConfig.encryptedValueFieldName].split(".");
+      assert.ok(resp.length === 5);
+      //Header is always constant
+      assert.strictEqual(
+        resp[0],
+        "eyJraWQiOiJnSUVQd1RxREdmenc0dXd5TElLa3d3UzNnc3c4NW5FWFkwUFA2QllNSW5rPSIsImN0eSI6ImFwcGxpY2F0aW9uL2pzb24iLCJhbGciOiJSU0EtT0FFUC0yNTYiLCJlbmMiOiJBMjU2R0NNIn0"
+      );
+      assert.ok(resp[1].length === 342);
+      assert.ok(resp[2].length === 22);
+      assert.ok(resp[3].length === 10);
+      assert.ok(resp[4].length === 22);
+    });
   });
 
   describe("#decryptData()", () => {
@@ -228,6 +246,13 @@ describe("JWE Crypto", () => {
           "eyJraWQiOiI3NjFiMDAzYzFlYWRlM2E1NDkwZTUwMDBkMzc4ODdiYWE1ZTZlYzBlMjI2YzA3NzA2ZTU5OTQ1MWZjMDMyYTc5IiwiY3R5IjoiYXBwbGljYXRpb25cL2pzb24iLCJlbmMiOiJBMjU2R0NNIiwiYWxnIjoiUlNBLU9BRVAtMjU2In0.8c6vxeZOUBS8A9SXYUSrRnfl1ht9xxciB7TAEv84etZhQQ2civQKso-htpa2DWFBSUm-UYlxb6XtXNXZxuWu-A0WXjwi1K5ZAACc8KUoYnqPldEtC9Q2bhbQgc_qZF_GxeKrOZfuXc9oi45xfVysF_db4RZ6VkLvY2YpPeDGEMX_nLEjzqKaDz_2m0Ae_nknr0p_Nu0m5UJgMzZGR4Sk1DJWa9x-WJLEyo4w_nRDThOjHJshOHaOU6qR5rdEAZr_dwqnTHrjX9Qm9N9gflPGMaJNVa4mvpsjz6LJzjaW3nJ2yCoirbaeJyCrful6cCiwMWMaDMuiBDPKa2ovVTy0Sw.w0Nkjxl0T9HHNu4R.suRZaYu6Ui05Z3-vsw.akknMr3Dl4L0VVTGPUszcA"
       );
       assert.ok(JSON.stringify(resp) === JSON.stringify({ foo: "bar" }));
+    });
+
+    it("with valid encrypted string", () => {
+      const resp = crypto.decryptData(
+        "eyJraWQiOiJnSUVQd1RxREdmenc0dXd5TElLa3d3UzNnc3c4NW5FWFkwUFA2QllNSW5rPSIsImN0eSI6ImFwcGxpY2F0aW9uL2pzb24iLCJhbGciOiJSU0EtT0FFUC0yNTYiLCJlbmMiOiJBMjU2R0NNIn0.vZBAXJC5Xcr0LaxdTRooLrbKc0B2cqjqAv3Dfz70s2EdUHf-swWPFe6QE-gb8PW7PQ-PZxkkIE5MhP6IMH4e/NH79V5j27c6Tno3R1/DfWQjRoN8xNm4sZver4FXESBiQia-PZip4D/hVmDWLKbom4SCD6ibLLmB9WcDVXpQEmX5G-lmd6kuEoBNOKQy08/QfVhqEr2H/2Q7PAcOjizPWUw6QK0SYzkaQIgTC6nlN/swa82zZa9NJeeTxJ1sJVmXzd4J-qjxwWjtzuRqb-kh4t/CUYT/lpf5NRaktBjXFyZFJ1dir5OgfdoA6-oIh8oUNMCt26SCCuYg-ev8sfHGDA.rxP1lOVCy4hIDwi5ETr2Bw.a3IIS9/6lA.77pOElwKjHBEwaPgRfHI4w"
+      );
+      assert.strictEqual(resp, "message");
     });
 
   });

--- a/test/jwe-encryption.test.js
+++ b/test/jwe-encryption.test.js
@@ -50,6 +50,15 @@ describe("JWE Encryption", () => {
         !Object.prototype.hasOwnProperty.call(res.foo, "encryptedData")
       );
     });
+
+    it("decrypt first level element in response", () => {
+      const encryption = new JweEncryption(testConfig);
+      const decrypt = JweEncryption.__get__("decrypt");
+      const response = require("./mock/jwe-response");
+      const res = decrypt.call(encryption, response);
+      assert.ok(res.decryptedData.accountNumber === "5123456789012345");
+      assert.ok(!res.encryptedData);
+    });
   });
 
   describe("#import JweEncryption", () => {

--- a/test/mock/jwe-config.js
+++ b/test/mock/jwe-config.js
@@ -13,6 +13,10 @@ module.exports = {
           element: "foo.elem1",
           obj: "foo",
         },
+        {
+          element: "encryptedData",
+          obj: "decryptedData",
+        },
       ],
     },
     {

--- a/test/mock/jwe-response.js
+++ b/test/mock/jwe-response.js
@@ -1,6 +1,7 @@
 module.exports = {
   request: { url: "/resource" },
   body: {
+    encryptedData : "eyJraWQiOiJnSUVQd1RxREdmenc0dXd5TElLa3d3UzNnc3c4NW5FWFkwUFA2QllNSW5rPSIsImN0eSI6ImFwcGxpY2F0aW9uL2pzb24iLCJhbGciOiJSU0EtT0FFUC0yNTYiLCJlbmMiOiJBMjU2R0NNIn0.bg6UTkMY9omV6CpXZnTsLNDQgKHVSOf7pO4KxhjkQfYSM6I2WBLNL8TMVFuVnOwGnq7jXwBBtszIj0Enk7nmwme2VNKnBEyoe-1t99j1VPX7CVQIdezNnJbwFl746Vi-izt6fatRPHUbp47pvZ7qL8u_xS9Ucv8-1HxuykoVbiHcY1lb-Mm_dzEJf-2eG0fkJxuVJBtUktrO0nu6BC_D53UULTxju6goGcjmgOqrAzf4Yg0NRrzObLchWisbzVcbzO0Lnv0rxDYYIeN54BSKpKowglQ8EElKqLx3rCZ8is6Un2nKqhzsY52-DAZ5-HLSCDCyjEO6CB1w8Y2CXvANZg.B5pVI2hqtwLFuiCNnzonAw.ZDnLiPNy63ocuwhYQFfSneS13Ff5GlFc87kegf8mnAJxGsYS.YFistvxKLMfLGVY5vWV_Dw",
     foo: {
       elem1: {
         encryptedData:


### PR DESCRIPTION
<!-- Please check the completed items below -->
### PR checklist

- [x] An issue/feature request has been created for this PR
- [x] Pull Request title clearly describes the work in the pull request and the Pull Request description provides details about how to validate the work. Missing information here may result in a delayed response.
- [x] File the PR against the `main` branch
- [x] The code in this PR is covered by unit tests

#### Link to issue/feature request: N/A

#### Description
Currently it is not possible to have encrypted value in first level field as well as decrypt from first level field using JWE (please see examples in updated README). This PR is adding this ability by specifying `encryptedValueFieldName` to be the same as `obj` (for encryption) or `element` (for decryption). 
Also it fixes encryption and decryption of primitive string values. Before the fix if we want to encrypt string it will add extra double quotes by JSON.stringify and then encrypt (e.g. 'value' becomes '"value"' and then encrypted). Decryption always expected JSON object and did not support primitive string at all. These two points have been addressed as well.