### PR TITLE
Add ability to encrypt and decrypt arrays with JWE

### DIFF
--- a/lib/mcapi/encryption/jwe-encryption.js
+++ b/lib/mcapi/encryption/jwe-encryption.js
@@ -64,11 +64,20 @@ function decrypt(response) {
  * @param body Body to encrypt
  */
 function encryptBody(path, body) {
-  const elem = utils.elemFromPath(path.element, body);
-  if (elem && elem.node) {
-    const encryptedData = this.crypto.encryptData({ data: elem.node });
-    body = utils.addEncryptedDataToBody(encryptedData, path, this.config.encryptedValueFieldName, body);
-  }
+  const pathsToFieldsToBeEncrypted = utils.replaceWildcardsWithIndexes(path.element, body);
+  const splitPathsToEncryptedFields = utils.splitPathByLastWildcard(path.obj);
+  const pathsToEncryptedFields = utils.replaceWildcardsWithIndexes(splitPathsToEncryptedFields[0], body);
+
+  pathsToFieldsToBeEncrypted.forEach((subPath, index) => {
+    const elem = utils.elemFromPath(subPath, body);
+    if (elem && elem.node) {
+      const pathToEncryptedFields = splitPathsToEncryptedFields.length === 1 ?
+        pathsToEncryptedFields[index] : pathsToEncryptedFields[index] + splitPathsToEncryptedFields[1];
+      const newPath = {element: subPath, obj: pathToEncryptedFields};
+      const encryptedData = this.crypto.encryptData({data: elem.node});
+      body = utils.addEncryptedDataToBody(encryptedData, newPath, this.config.encryptedValueFieldName, body);
+    }
+  });
   return body;
 }
 
@@ -81,19 +90,31 @@ function encryptBody(path, body) {
  * @returns {Object} Decrypted body
  */
 function decryptBody(path, body) {
-  const elem = utils.elemFromPath(path.element, body);
-  if (elem && elem.node) {
-    const encryptedValue = (path.element === this.config.encryptedValueFieldName) ?
-      elem.node : elem.node[this.config.encryptedValueFieldName];
-    const decryptedObj = this.crypto.decryptData(encryptedValue);
-    return utils.mutateObjectProperty(
-      path.obj,
-      decryptedObj,
-      body,
-      path.element,
-      []
-    );
-  }
+  const pathsToEncryptedFields = utils.replaceWildcardsWithIndexes(path.element, body);
+  const splitPathsToDecryptedFields = utils.splitPathByLastWildcard(path.obj);
+  const pathsToDecryptedFields = utils.replaceWildcardsWithIndexes(splitPathsToDecryptedFields[0], body);
+
+  pathsToEncryptedFields.forEach((subPath, index) => {
+    const elem = utils.elemFromPath(subPath, body);
+    if (elem && elem.node) {
+      const encryptedValue = (subPath === this.config.encryptedValueFieldName) ?
+        elem.node : elem.node[this.config.encryptedValueFieldName];
+      // in case we have path to Array index we do not want to delete entire node but just encrypted field
+      const pathToDelete = isNaN(subPath.split(".").pop()) ?
+        subPath : subPath + "." + this.config.encryptedValueFieldName;
+      const decryptedObj = this.crypto.decryptData(encryptedValue);
+      const pathToDecryptedFields = splitPathsToDecryptedFields.length === 1 ?
+        pathsToDecryptedFields[index] : pathsToDecryptedFields[index] + splitPathsToDecryptedFields[1];
+      body = utils.mutateObjectProperty(
+        pathToDecryptedFields,
+        decryptedObj,
+        body,
+        pathToDelete,
+        []
+      );
+    }
+  });
+
   return body;
 }
 

--- a/lib/mcapi/utils/utils.js
+++ b/lib/mcapi/utils/utils.js
@@ -139,7 +139,7 @@ module.exports.mutateObjectProperty = function (
       tmp = tmp[e];
     });
     const elem = path.split(".").pop();
-    if (elem === "$") {
+    if (isJsonRoot(elem)) {
       obj = value; // replace root
     } else if (typeof value === "object" && !(value instanceof Array)) {
       // decrypted value
@@ -412,43 +412,65 @@ module.exports.hasConfig = function(config, endpoint) {
   return null;
 };
 
+/**
+ * Return paths with replaced * wildcard to existing Array indexes.
+ * E.g. *.path.to.*.foo will return [ 0.path.to.0.foo, 0.path.to.1.foo, 1.path.to.0.foo ]
+ *
+ * @private
+ * @param path JSON path with or without * wildcards
+ * @param jsonArray JSON body
+ * @returns {Array} Paths with replaced *
+ */
 module.exports.replaceWildcardsWithIndexes = function (path, jsonArray) {
   if (!path.includes("*")) {
-    return path;
+    return [path];
   }
-  const indexes = [];
-  function traverse(obj, currentPath) {
-    if (Array.isArray(obj)) {
-      obj.forEach((item, index) => {
-        traverse(item, `${currentPath}.${index}`);
-      });
-    } else if (typeof obj === 'object') {
-      for (const key in obj) {
-        traverse(obj[key], `${currentPath}.${key}`);
+  const pathsWithReplacedWildcard = [];
+
+  try {
+    traverseJson(jsonArray, '', pathsWithReplacedWildcard);
+
+    // replace * in path to regex that matches any number
+    const regexPattern = new RegExp(
+      `^(${path.replace(/\*/g, '\\d+').replace(/\./g, '\\.')})`
+    );
+    const matches = pathsWithReplacedWildcard.map(str => {
+      const match = str.match(regexPattern);
+      if (match !== null) {
+        return match[1];
       }
-    } else {
-      indexes.push(currentPath);
-    }
+    }).filter(match => match !== undefined);
+
+    return [...new Set(matches)];
+  } catch (e) {
+    throw new Error("Error during replacing wildcard in path");
   }
-  traverse(jsonArray, '');
+};
 
-  const indexesWithoutFirstDot = indexes.map(str => {
-    if (str.startsWith('.')) {
-      return str.substring(1);
+function traverseJson(obj, currentPath, output) {
+  if (Array.isArray(obj)) {
+    obj.forEach((item, index) => {
+      traverseJson(item, `${currentPath}.${index}`, output);
+    });
+  } else if (typeof obj === 'object') {
+    for (const key in obj) {
+      traverseJson(obj[key], `${currentPath}.${key}`, output);
     }
-    return str;
-  });
+  } else {
+    output.push(currentPath.substring(1));
+  }
+};
 
-  const regexPattern = new RegExp(
-    `^(${path.replace(/\*/g, '\\d+').replace(/\./g, '\\.')})`
-  );
+module.exports.splitPathByLastWildcard = function (path) {
+  const lastAsteriskIndex = path.lastIndexOf("*");
 
-  const matches = indexesWithoutFirstDot.map(str => {
-    const match = str.match(regexPattern);
-    if (match) return match[1];
-  }).filter(match => match !== undefined);
-  return [...new Set(matches)];
-}
+  if (lastAsteriskIndex !== -1) {
+    const partBefore = path.slice(0, lastAsteriskIndex + 1);
+    const partAfter = path.slice(lastAsteriskIndex + 1);
+    return [partBefore, partAfter];
+  }
+  return [path];
+};
 
 module.exports.elemFromPath = function (path, obj) {
   try {
@@ -504,11 +526,11 @@ module.exports.readPublicCertificateContent = function (config) {
     throw new Error("Public certificate content is not valid");
   }
     return forge.pki.certificateFromPem(config.encryptionCertificate);
-}
+};
 
 module.exports.getPrivateKeyFromContent = function(config) {
   if (config.privateKey) {
     return forge.pki.privateKeyFromPem(config.privateKey);
   }
   return null;
-}
+};

--- a/lib/mcapi/utils/utils.js
+++ b/lib/mcapi/utils/utils.js
@@ -412,6 +412,44 @@ module.exports.hasConfig = function(config, endpoint) {
   return null;
 };
 
+module.exports.replaceWildcardsWithIndexes = function (path, jsonArray) {
+  if (!path.includes("*")) {
+    return path;
+  }
+  const indexes = [];
+  function traverse(obj, currentPath) {
+    if (Array.isArray(obj)) {
+      obj.forEach((item, index) => {
+        traverse(item, `${currentPath}.${index}`);
+      });
+    } else if (typeof obj === 'object') {
+      for (const key in obj) {
+        traverse(obj[key], `${currentPath}.${key}`);
+      }
+    } else {
+      indexes.push(currentPath);
+    }
+  }
+  traverse(jsonArray, '');
+
+  const indexesWithoutFirstDot = indexes.map(str => {
+    if (str.startsWith('.')) {
+      return str.substring(1);
+    }
+    return str;
+  });
+
+  const regexPattern = new RegExp(
+    `^(${path.replace(/\*/g, '\\d+').replace(/\./g, '\\.')})`
+  );
+
+  const matches = indexesWithoutFirstDot.map(str => {
+    const match = str.match(regexPattern);
+    if (match) return match[1];
+  }).filter(match => match !== undefined);
+  return [...new Set(matches)];
+}
+
 module.exports.elemFromPath = function (path, obj) {
   try {
     let parent = null;

--- a/test/jwe-encryption.test.js
+++ b/test/jwe-encryption.test.js
@@ -4,6 +4,7 @@ const JweEncryption = rewire("../lib/mcapi/encryption/jwe-encryption");
 const utils = require("../lib/mcapi/utils/utils");
 
 const testConfig = require("./mock/jwe-config");
+const encryptedData = "eyJraWQiOiJnSUVQd1RxREdmenc0dXd5TElLa3d3UzNnc3c4NW5FWFkwUFA2QllNSW5rPSIsImN0eSI6ImFwcGxpY2F0aW9uL2pzb24iLCJhbGciOiJSU0EtT0FFUC0yNTYiLCJlbmMiOiJBMjU2R0NNIn0.bg6UTkMY9omV6CpXZnTsLNDQgKHVSOf7pO4KxhjkQfYSM6I2WBLNL8TMVFuVnOwGnq7jXwBBtszIj0Enk7nmwme2VNKnBEyoe-1t99j1VPX7CVQIdezNnJbwFl746Vi-izt6fatRPHUbp47pvZ7qL8u_xS9Ucv8-1HxuykoVbiHcY1lb-Mm_dzEJf-2eG0fkJxuVJBtUktrO0nu6BC_D53UULTxju6goGcjmgOqrAzf4Yg0NRrzObLchWisbzVcbzO0Lnv0rxDYYIeN54BSKpKowglQ8EElKqLx3rCZ8is6Un2nKqhzsY52-DAZ5-HLSCDCyjEO6CB1w8Y2CXvANZg.B5pVI2hqtwLFuiCNnzonAw.ZDnLiPNy63ocuwhYQFfSneS13Ff5GlFc87kegf8mnAJxGsYS.YFistvxKLMfLGVY5vWV_Dw";
 
 describe("JWE Encryption", () => {
   before(function () {
@@ -36,6 +37,119 @@ describe("JWE Encryption", () => {
       assert.ok(res.body.elem1.encryptedData);
       assert.ok(!res.body.elem1.encryptedData.accountNumber);
     });
+
+    it("encrypt request body with arrays", () => {
+      // arrange
+      const pathUrl = "encrypt/array/one";
+      testConfig.paths.push(
+        {
+          path: pathUrl,
+          toEncrypt: [
+            {
+              element: "*.elem1",
+              obj: "*",
+            }
+          ],
+          toDecrypt: [],
+        });
+      const request = [
+        { elem1: { accountNumber: "5123456789012345"}, elem2: "value" },
+        { elem1: { accountNumber: "5123456789012345"}, elem2: "value" }
+      ];
+
+      const encryption = new JweEncryption(testConfig);
+      const encrypt = JweEncryption.__get__("encrypt");
+
+      // act
+      const res = encrypt.call(encryption, pathUrl, null, request);
+
+      // assert
+      assert.ok(res.body[0].encryptedData);
+      assert.ok(res.body[1].encryptedData);
+      assert.ok(res.body[0].elem2);
+      assert.ok(res.body[1].elem2);
+      assert.ok(!res.body[0].elem1);
+      assert.ok(!res.body[1].elem1);
+      assert.ok(
+        !Object.prototype.hasOwnProperty.call(res.body[0], "elem1")
+      );
+    });
+
+    it("encrypt request body with multiple arrays", () => {
+      // arrange
+      const pathUrl = "encrypt/array/two";
+      testConfig.paths.push(
+        {
+          path: pathUrl,
+          toEncrypt: [
+            {
+              element: "*.elem1.*",
+              obj: "*.elem1.*",
+            }
+          ],
+          toDecrypt: [],
+        });
+      const request = [
+        { elem1: [{ accountNumber: "5123456789012345"}, { accountNumber: "5123456789012345"}], elem2: "value" },
+        { elem1: [{ accountNumber: "5123456789012345"}, { accountNumber: "5123456789012345"}], elem2: "value" }
+      ];
+
+      const encryption = new JweEncryption(testConfig);
+      const encrypt = JweEncryption.__get__("encrypt");
+
+      // act
+      const res = encrypt.call(encryption, pathUrl, null, request);
+
+      // assert
+      assert.ok(res.body[0].elem1[0].encryptedData);
+      assert.ok(res.body[0].elem1[1].encryptedData);
+      assert.ok(res.body[1].elem1[0].encryptedData);
+      assert.ok(res.body[1].elem1[1].encryptedData);
+      assert.ok(res.body[0].elem2);
+      assert.ok(res.body[1].elem2);
+      assert.ok(!res.body[0].elem1[0].accountNumber);
+      assert.ok(!res.body[1].elem1[1].accountNumber);
+      assert.ok(
+        !Object.prototype.hasOwnProperty.call(res.body[0].elem1[0], "accountNumber")
+      );
+    });
+
+    it("encrypt request body with arrays to new field", () => {
+      // arrange
+      const pathUrl = "encrypt/array/three";
+      testConfig.paths.push(
+        {
+          path: pathUrl,
+          toEncrypt: [
+            {
+              element: "*.elem1",
+              obj: "*.newElem",
+            }
+          ],
+          toDecrypt: [],
+        });
+      const request = [
+        { elem1: { accountNumber: "5123456789012345"}, elem2: "value" },
+        { elem1: { accountNumber: "5123456789012345"}, elem2: "value" }
+      ];
+
+      const encryption = new JweEncryption(testConfig);
+      const encrypt = JweEncryption.__get__("encrypt");
+
+      // act
+      const res = encrypt.call(encryption, pathUrl, null, request);
+
+      // assert
+      assert.ok(res.body[0].newElem.encryptedData);
+      assert.ok(res.body[1].newElem.encryptedData);
+      assert.ok(res.body[0].elem2);
+      assert.ok(res.body[1].elem2);
+      assert.ok(!res.body[0].elem1);
+      assert.ok(!res.body[1].elem1);
+      assert.ok(
+        !Object.prototype.hasOwnProperty.call(res.body[0], "elem1")
+      );
+    });
   });
 
   describe("#decrypt", () => {
@@ -58,6 +172,114 @@ describe("JWE Encryption", () => {
       const res = decrypt.call(encryption, response);
       assert.ok(res.decryptedData.accountNumber === "5123456789012345");
       assert.ok(!res.encryptedData);
+    });
+
+    it("decrypt response body with arrays", () => {
+      // arrange
+      const pathUrl = "decrypt/array/one";
+      testConfig.paths.push(
+        {
+          path: pathUrl,
+          toEncrypt: [],
+          toDecrypt: [
+            {
+              element: "elem2.*.elem3.*",
+              obj: "elem2.*.elem3.*",
+            }
+          ],
+        });
+      const response = {
+        request: { url: pathUrl },
+        body: {
+          elem1: { elem2: "value"},
+          elem2: [{ elem3: [{ encryptedData: encryptedData, elem5: "value" }]}, { elem3: [{ encryptedData : encryptedData, elem5: "value" }]}]
+        }
+      };
+
+      const encryption = new JweEncryption(testConfig);
+      const decrypt = JweEncryption.__get__("decrypt");
+
+      // act
+      const res = decrypt.call(encryption, response);
+
+      // assert
+      assert.strictEqual(res.elem2[0].elem3[0].accountNumber, "5123456789012345");
+      assert.strictEqual(res.elem2[1].elem3[0].accountNumber, "5123456789012345");
+      assert.ok(res.elem2[0].elem3[0].elem5);
+      assert.ok(!res.elem2[0].elem3[0].encryptedData);
+      assert.ok(
+        !Object.prototype.hasOwnProperty.call(res.elem2[0].elem3[0], "encryptedData")
+      );
+    });
+
+    it("decrypt response body with arrays to new element", () => {
+      // arrange
+      const pathUrl = "decrypt/array/two";
+      testConfig.paths.push(
+        {
+          path: pathUrl,
+          toEncrypt: [],
+          toDecrypt: [
+            {
+              element: "*.elem1",
+              obj: "*.elem1.newElem",
+            }
+          ],
+        });
+      const response = {
+        request: { url: pathUrl },
+        body: [{ elem1: { encryptedData: encryptedData }, elem2: "value" }, { elem1: { encryptedData : encryptedData }, elem2: "value" }]
+      };
+
+      const encryption = new JweEncryption(testConfig);
+      const decrypt = JweEncryption.__get__("decrypt");
+
+      // act
+      const res = decrypt.call(encryption, response);
+
+      // assert
+      assert.strictEqual(res[0].elem1.newElem.accountNumber, "5123456789012345");
+      assert.strictEqual(res[1].elem1.newElem.accountNumber, "5123456789012345");
+      assert.ok(!res[0].elem1.encryptedData);
+      assert.ok(res[0].elem2);
+      assert.ok(
+        !Object.prototype.hasOwnProperty.call(res[0].elem1, "encryptedData")
+      );
+    });
+
+    it("decrypt response body with arrays where path is ended with wildcard", () => {
+      // arrange
+      const pathUrl = "decrypt/array/three";
+      testConfig.paths.push(
+        {
+          path: pathUrl,
+          toEncrypt: [],
+          toDecrypt: [
+            {
+              element: "*",
+              obj: "*",
+            }
+          ],
+        });
+      const response = {
+        request: { url: pathUrl },
+        body: [{ encryptedData: encryptedData, elem2: "value" }, { encryptedData : encryptedData, elem2: "value" }]
+      };
+
+      const encryption = new JweEncryption(testConfig);
+      const decrypt = JweEncryption.__get__("decrypt");
+
+      // act
+      const res = decrypt.call(encryption, response);
+
+      // assert
+      assert.strictEqual(res[0].accountNumber, "5123456789012345");
+      assert.strictEqual(res[1].accountNumber, "5123456789012345");
+      assert.ok(res[0].elem2);
+      assert.ok(!res[0].encryptedData);
+      assert.ok(
+        !Object.prototype.hasOwnProperty.call(res[0], "encryptedData")
+      );
     });
   });
 

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -594,4 +594,84 @@ describe("Utils", () => {
     });
   });
 
+  describe("#utils.splitPathByLastWildcard", () => {
+    it("path with wildcard", () => {
+      const res = utils.splitPathByLastWildcard("elem1.*.elem2");
+      assert.strictEqual(JSON.stringify(res), JSON.stringify(["elem1.*", ".elem2"]));
+    });
+
+    it("path without wildcard", () => {
+      const res = utils.splitPathByLastWildcard("elem1.elem2");
+      assert.strictEqual(JSON.stringify(res), JSON.stringify(["elem1.elem2"]));
+    });
+
+    it("path with several wildcards", () => {
+      const res = utils.splitPathByLastWildcard("*.elem1.*.elem2");
+      assert.strictEqual(JSON.stringify(res), JSON.stringify(["*.elem1.*", ".elem2"]));
+    });
+
+    it("path only with wildcard", () => {
+      const res = utils.splitPathByLastWildcard("*");
+      assert.strictEqual(JSON.stringify(res), JSON.stringify(["*", ""]));
+    });
+
+    it("path with last wildcard", () => {
+      const res = utils.splitPathByLastWildcard("elem1.*");
+      assert.strictEqual(JSON.stringify(res), JSON.stringify(["elem1.*", ""]));
+    });
+
+    it("path with first wildcard", () => {
+      const res = utils.splitPathByLastWildcard("*.elem1");
+      assert.strictEqual(JSON.stringify(res), JSON.stringify(["*", ".elem1"]));
+    });
+
+    it("empty path", () => {
+      const res = utils.splitPathByLastWildcard("");
+      assert.strictEqual(JSON.stringify(res), JSON.stringify([""]));
+    });
+  });
+
+  describe("#utils.replaceWildcardsWithIndexes", () => {
+    it("path with *", () => {
+      const json = { elem1: "value", elem2: [{ elem3: { elem4: "value", elem5: "value" } }, { elem3: { elem4 : "value", elem5: "value" } } ]};
+      const path = "elem2.*";
+      const res = utils.replaceWildcardsWithIndexes(path, json);
+      assert.strictEqual(JSON.stringify(res), JSON.stringify(["elem2.0", "elem2.1"]));
+    });
+
+    it("path without *", () => {
+      const json = { elem1: { elem2: "value"}, elem2: [{ elem3: { elem4: "value", elem5: "value" } }, { elem3: { elem4 : "value", elem5: "value" } } ]};
+      const path = "elem1.elem2";
+      const res = utils.replaceWildcardsWithIndexes(path, json);
+      assert.strictEqual(JSON.stringify(res), JSON.stringify(["elem1.elem2"]));
+    });
+
+    it("path with multiple *", () => {
+      const json = { elem1: { elem2: "value"}, elem2: [{ elem3: [{ elem4: "value", elem5: "value" }] }, { elem3: [{ elem4 : "value", elem5: "value" }] } ]};
+      const path = "elem2.*.elem3.*";
+      const res = utils.replaceWildcardsWithIndexes(path, json);
+      assert.strictEqual(JSON.stringify(res), JSON.stringify(["elem2.0.elem3.0", "elem2.1.elem3.0"]));
+    });
+
+    it("path with * but no array in JSON", () => {
+      const json = { elem1: { elem2: "value"}, elem2: { elem3: { elem4: "value", elem5: "value" } }};
+      const path = "elem2.*";
+      const res = utils.replaceWildcardsWithIndexes(path, json);
+      assert.strictEqual(JSON.stringify(res), JSON.stringify([]));
+    });
+
+    it("path with only *", () => {
+      const json = [{ elem3: { elem4: "value", elem5: "value" } }, { elem3: { elem4 : "value", elem5: "value" } } ];
+      const path = "*";
+      const res = utils.replaceWildcardsWithIndexes(path, json);
+      assert.strictEqual(JSON.stringify(res), JSON.stringify(["0", "1"]));
+    });
+
+    it("empty path", () => {
+      const json = { elem1: { elem2: "value"}, elem2: { elem3: { elem4: "value", elem5: "value" } }};
+      const path = "";
+      const res = utils.replaceWildcardsWithIndexes(path, json);
+      assert.strictEqual(JSON.stringify(res), JSON.stringify([""]));
+    });
+  });
 });


### PR DESCRIPTION
<!-- Please check the completed items below -->
### PR checklist

- [x] An issue/feature request has been created for this PR
- [x] Pull Request title clearly describes the work in the pull request and the Pull Request description provides details about how to validate the work. Missing information here may result in a delayed response.
- [x] File the PR against the `main` branch
- [x] The code in this PR is covered by unit tests

#### Link to issue/feature request: N/A

#### Description
Added an ability to encrypt and decrypt fields in arrays using JWE. Array index is specified using * wildcard in path config, e.g.: `*.path.to.*.foo`. This path will be converted to array of paths based on the body e.g. `[ 0.path.to.0.foo, 0.path.to.1.foo, 1.path.to.0.foo ]`. These paths now will be used for encryption/decryption.