### PR TITLE
Fix decryption failure for entire payload when request object is encr…

### DIFF
--- a/lib/mcapi/encryption/jwe-encryption.js
+++ b/lib/mcapi/encryption/jwe-encryption.js
@@ -84,7 +84,7 @@ function decryptBody(path, body) {
   const elem = utils.elemFromPath(path.element, body);
   if (elem && elem.node) {
     const encryptedValue = (path.element === this.config.encryptedValueFieldName) ?
-      elem.node : elem.node[this.config.encryptedValueFieldName];
+      elem.node : elem.node instanceof Object ? elem.node[this.config.encryptedValueFieldName] : elem.node;
     const decryptedObj = this.crypto.decryptData(encryptedValue);
     return utils.mutateObjectProperty(
       path.obj,

--- a/lib/mcapi/mcapi-service.js
+++ b/lib/mcapi/mcapi-service.js
@@ -45,6 +45,9 @@ function Service(service, config) {
         }
         arguments[arguments.length - 1] = function (error, data, response) {
           if (response && response.body) {
+            if(response.returnApiResponse) {
+              response.body = response.returnApiResponse;
+            }
             const decryptedPayload = outObj.encryption.decrypt(response);
             response.body = decryptedPayload;
             data = decryptedPayload;

--- a/test/jwe-encryption.test.js
+++ b/test/jwe-encryption.test.js
@@ -70,3 +70,27 @@ describe("JWE Encryption", () => {
     });
   });
 });
+
+describe("#", () => {
+  it("entire payload encryption and decryption where request and response object is different", () => {
+    const encryption = new JweEncryption(testConfig);
+    const encrypt = JweEncryption.__get__("encrypt");
+    const encryptedPayload = encrypt.call(encryption, "/entirepayload", null,
+      {
+        externalReference: "48956hguyguy23g4234",
+        amount: "2",
+        payers: [{ accountAlias: "stg_earmark_payer1withcryptoaddr", amount: "2" }],
+        recipients: [{ accountAlias: "stg_earmark_recip1WithCryptoAddr", amount: "1" }]
+      });
+    encryptedPayload.body.encryptedResponse = encryptedPayload.body.encryptedData;
+    delete encryptedPayload.body.encryptedData;
+
+    const decrypt = JweEncryption.__get__("decrypt");
+    encryptedPayload.request = { url: "/entirepayload" }
+    const res = decrypt.call(encryption, encryptedPayload);
+    assert.ok(res.externalReference === "48956hguyguy23g4234");
+    assert.ok(res.amount === "2");
+    assert.ok(res.payers[0].accountAlias === "stg_earmark_payer1withcryptoaddr");
+    assert.ok(res.recipients[0].accountAlias === "stg_earmark_recip1WithCryptoAddr");
+  });
+});

--- a/test/mcapi-service.test.js
+++ b/test/mcapi-service.test.js
@@ -1,6 +1,7 @@
 const assert = require("assert");
 const MCService = require("../lib/mcapi/mcapi-service");
 const testConfig = require("./mock/config");
+const testJweConfig = require("./mock/jwe-config")
 
 describe("MC API Service", () => {
   describe("#interceptor", () => {
@@ -145,3 +146,59 @@ describe("MC API Service", () => {
     });
   });
 });
+
+/* This test case showcases the encryption and decryption of the entire payload using JWE. It describes a scenario where encryption generates encryptedData object. Upon making an API call, the API responds with an encryptedResponse object. The test verifies the ability to decrypt the encryptedResponse object. */
+it("Intercepting ApiClient's callApi with JWE Encryption/Decryption for Entire Payload, Utilizing Different Request and Response Objects",
+  function (done) {
+    const postBody = {
+      externalReference: "48956hguyguy23g4234",
+      amount: "2",
+      payers: [{ accountAlias: "stg_earmark_payer1withcryptoaddr-999000", amount: "2" }],
+      recipients: [{ accountAlias: "stg_earmark_recip1WithCryptoAddr-999001", amount: "1" }]
+    };
+    const respEnc =
+    {
+      encryptedResponse: 'eyJraWQiOiJnSUVQd1RxREdmenc0dXd5TElLa3d3UzNnc3c4NW5FWFkwUFA2QllNSW5rPSIsImN0eSI6ImFwcGxpY2F0aW9uL2pzb24iLCJhbGciOiJSU0EtT0FFUC0yNTYiLCJlbmMiOiJBMjU2R0NNIn0.' +
+        'flEVAmFsw70aH6cyCmU8PmJSGBjWM8QU8rQg2IvfHZjvBq0O7qtRjIn9ssmTlYAohXxO4uIuECUWv9NILdZnKd20wtgihBmrflKVhVZ8afJESFIEcF4vIY03QBou0u4bGVNtrC0XooPy6uRnkZzlcvDZyMVMJF4eEK1-PSx7Gf77Vj9q37S' +
+        'IHsVCo4EujDi6Y1qRz2kI86eIguLeJbFmL1VcOUyrt8jtjcj00utFm30j-PyOEwgiyhYI6F0eMUWT89d-QYQrInk-Ciyp4bYwsLcr85BOMqWZ8nc2CGu2rfBNGexCphxDUJQ/TWEBZ0XKBAaQOj5qszwXhO-synLJ3A.eIGqscNMcz5h8x8w26oc6A.' +
+        'y-66zjYqTEqmgV39rklNVKgCF1Uq6jf-sLKOOkkX6RZJsAl4UY4cHWEfWcJCgnMnS8ZE/sBen24FwjZrxlC/znJa4D-BoY4OK0oE/GQJZ9mkmzwbqKeBFLzmalVLG2/XH74TY6bVn5xtVSR9tCalEMjIEo/Wwyt1DbIdysFqfcmXUbJo4bmKx6rfpBbXn' +
+        'cOopJ8nxQZaXueM1BcZQykS8bl4GriF2NgtPdjz6aqXsxDihd3p7LpbobrdcFtZvsMTs6xTRia9q9qqzN70cKwM8lBftMdRovRa-JCrkJ7LDqDQ/A.cdFqkuHXnggBcfxugl8cBA'
+    };
+    const service = {
+      ApiClient: {
+        instance: {
+          callApi: function () {
+            arguments[arguments.length - 1](null, arguments[7],
+              {
+                body: arguments[7],
+                request: { url: "/entirepayload" },
+                returnApiResponse: respEnc,
+              });
+          },
+        },
+      },
+    };
+    const mcService = new MCService(service, testJweConfig);
+    // simulate callApi call from client 
+    service.ApiClient.instance.callApi.call(mcService,
+      "/entirepayload",
+      "POST",
+      null,
+      null,
+      null,
+      { test: "header" },
+      null,
+      postBody,
+      null,
+      null,
+      null,
+      null,
+      null,
+      function cb(error, data) {
+        assert.ok(data.externalReference);
+        assert.ok(data.amount);
+        assert.ok(data.payers);
+        assert.ok(data.recipients);
+        done();
+      });
+  });

--- a/test/mock/jwe-config.js
+++ b/test/mock/jwe-config.js
@@ -64,6 +64,19 @@ module.exports = {
         },
       ],
     },
+    {
+      path: "/entirepayload",
+      toEncrypt: [
+        {
+          element: "$", obj: "$",
+        },
+      ],
+      toDecrypt: [
+        {
+          element: "encryptedResponse", obj: "$",
+        }
+      ],
+    }
   ],
   mode: "JWE",
   encryptedValueFieldName: "encryptedData",


### PR DESCRIPTION
Fix decryption failure for entire payload when request object is encryptedData and response is encryptedResponse

The decryption process failed for the entire payload when the request object was encryptedData and the response was encryptedResponse from the API. This issue occurred due to a conditional statement that incorrectly retrieved the encrypted value.

- jwe-encryption.js modified the logic
- mcapi-service.js added logic for testing
- jwe-encryptioin.test.js testcase for same bug
- jwe-config.js added config for test
- mcapi-service.test.js added test for same bug


#### Link to issue/feature request: *add the link here*
**Here is the scenario:** 
When encrypting the entire payload and assigning it to encryptedData, and subsequently making an API call, the response is received as an encryptedResponse object. In this case, while decrypting response object an error is thrown due to invalid input.

**My config**
{
    "path": "/entirepayload",
    "toEncrypt": [{ "element": "$", "obj": "$" }],
    "toDecrypt": [{ "element": "encryptedResponse", "obj": "$" }],
    "mode": "JWE",
    "encryptedValueFieldName": "encryptedData",
    "publicKeyFingerprintType": "certificate",
    "dataEncoding": "base64",
    "encryptionCertificate": "./test/res/test_certificate.cert",
    "privateKey": "./test/res/test_key.der"
}

 
 **Sample response I recived from API:**
  {
      encryptedResponse: 'eyJraWQiOiJnSUVQd1RxREdmenc0dXd5TElLa3d3UzNnc3c4NW5FWFkwUFA2QllNSW5rPSIsImN0eSI6ImFwcGxpY2F0aW9uL2pzb24iLCJhbGciOiJSU0EtT0FFUC0yNTYiLCJlbmMiOiJBMjU2R0NNIn0.' +
        'flEVAmFsw70aH6cyCmU8PmJSGBjWM8QU8rQg2IvfHZjvBq0O7qtRjIn9ssmTlYAohXxO4uIuECUWv9NILdZnKd20wtgihBmrflKVhVZ8afJESFIEcF4vIY03QBou0u4bGVNtrC0XooPy6uRnkZzlcvDZyMVMJF4eEK1-PSx7Gf77Vj9q37S' +
        'IHsVCo4EujDi6Y1qRz2kI86eIguLeJbFmL1VcOUyrt8jtjcj00utFm30j-PyOEwgiyhYI6F0eMUWT89d-QYQrInk-Ciyp4bYwsLcr85BOMqWZ8nc2CGu2rfBNGexCphxDUJQ/TWEBZ0XKBAaQOj5qszwXhO-synLJ3A.eIGqscNMcz5h8x8w26oc6A.' +
        'y-66zjYqTEqmgV39rklNVKgCF1Uq6jf-sLKOOkkX6RZJsAl4UY4cHWEfWcJCgnMnS8ZE/sBen24FwjZrxlC/znJa4D-BoY4OK0oE/GQJZ9mkmzwbqKeBFLzmalVLG2/XH74TY6bVn5xtVSR9tCalEMjIEo/Wwyt1DbIdysFqfcmXUbJo4bmKx6rfpBbXn' +
        'cOopJ8nxQZaXueM1BcZQykS8bl4GriF2NgtPdjz6aqXsxDihd3p7LpbobrdcFtZvsMTs6xTRia9q9qqzN70cKwM8lBftMdRovRa-JCrkJ7LDqDQ/A.cdFqkuHXnggBcfxugl8cBA'
    }
    
This encapsulates the issue description along with the provided configuration and a sample response from the API.
